### PR TITLE
Added Ubuntu wildcard to FQDN rules

### DIFF
--- a/app-fqdn-rules.tf
+++ b/app-fqdn-rules.tf
@@ -4,6 +4,7 @@ locals {
     tcp = {
       "*.aviatrix.com" = "443"
       "aviatrix.com"   = "80"
+      "*.ubuntu.com"   = "80"
     }
     udp = {
       "dns.google.com" = "53"


### PR DESCRIPTION
Add *.ubuntu.com to the FQDN filter. This will allow the following two commands to work:

sudo apt-get update -y
sudo apt-get upgrade -y
